### PR TITLE
feat: handle hashes without throwing an error

### DIFF
--- a/requirements/parser.py
+++ b/requirements/parser.py
@@ -62,6 +62,9 @@ def parse(reqstr: Union[str, TextIO]) -> Iterator[Requirement]:
         elif not line or line.startswith('#'):
             # comments are lines that start with # only
             continue
+        elif not line or line.startswith('--hash='):
+            # hashes are lines that start with --hash=
+            continue
         elif line.startswith('-r') or line.startswith('--requirement'):
             _, new_filename = line.split()
             new_file_path = os.path.join(os.path.dirname(filename or '.'),

--- a/requirements/requirement.py
+++ b/requirements/requirement.py
@@ -251,4 +251,9 @@ class Requirement:
             return cls.parse_editable(
                 re.sub(r'^(-e|--editable=?)\s*', '', line))
 
+        if ' --hash=' in line:
+            line = line[:line.find(' --hash=')]
+        if ' \\' in line:
+            line = line[:line.find(' \\')]
+
         return cls.parse_line(line)

--- a/tests/reqfiles/hash_1.expected
+++ b/tests/reqfiles/hash_1.expected
@@ -1,0 +1,44 @@
+[
+ {
+  "specifier": true,
+  "local_file": false,
+  "name": "packaging",
+  "editable": false,
+  "subdirectory": null,
+  "uri": null,
+  "extras": [],
+  "vcs": null,
+  "path": null,
+  "line":  "packaging==21.3",
+  "hash_name": null,
+  "hash": null,
+  "specs": [
+   [
+    "==",
+    "21.3"
+   ]
+  ],
+  "revision": null
+ },
+ {
+  "specifier": true,
+  "local_file": false,
+  "name": "packaging",
+  "editable": false,
+  "subdirectory": null,
+  "uri": null,
+  "extras": [],
+  "vcs": null,
+  "path": null,
+  "line":  "packaging==21.3",
+  "hash_name": null,
+  "hash": null,
+  "specs": [
+   [
+    "==",
+    "21.3"
+   ]
+  ],
+  "revision": null
+ }
+]

--- a/tests/reqfiles/hash_1.txt
+++ b/tests/reqfiles/hash_1.txt
@@ -1,0 +1,7 @@
+packaging==21.3 \
+    --hash=sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522 \
+    --hash=sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522
+    # testing
+packaging==21.3 \
+    --hash=sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522 \
+    --hash=sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522

--- a/tests/reqfiles/hash_2.expected
+++ b/tests/reqfiles/hash_2.expected
@@ -1,0 +1,23 @@
+[
+ {
+  "specifier": true,
+  "local_file": false,
+  "name": "packaging",
+  "editable": false,
+  "subdirectory": null,
+  "uri": null,
+  "extras": [],
+  "vcs": null,
+  "path": null,
+  "line":  "packaging==21.3",
+  "hash_name": null,
+  "hash": null,
+  "specs": [
+   [
+    "==",
+    "21.3"
+   ]
+  ],
+  "revision": null
+ }
+]

--- a/tests/reqfiles/hash_2.txt
+++ b/tests/reqfiles/hash_2.txt
@@ -1,0 +1,1 @@
+packaging==21.3 --hash=sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522


### PR DESCRIPTION
This should allow the requirements parser to handle files that have hashes in them. Nothing is done with the hash information. 

Tests were also added for both single and multi line hashes

should fix: https://github.com/madpah/requirements-parser/issues/51