### PR TITLE
feat: allow skipping requirements file includes

### DIFF
--- a/requirements/parser.py
+++ b/requirements/parser.py
@@ -39,7 +39,7 @@ _UNSUPPORTED_OPTIONS = {
 }
 
 
-def parse(reqstr: Union[str, TextIO]) -> Iterator[Requirement]:
+def parse(reqstr: Union[str, TextIO], skip_includes: bool=False) -> Iterator[Requirement]:
     """
     Parse a requirements file into a list of Requirements
 
@@ -63,6 +63,8 @@ def parse(reqstr: Union[str, TextIO]) -> Iterator[Requirement]:
             # comments are lines that start with # only
             continue
         elif line.startswith('-r') or line.startswith('--requirement'):
+            if skip_includes:
+                continue
             _, new_filename = line.split()
             new_file_path = os.path.join(os.path.dirname(filename or '.'),
                                          new_filename)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -44,6 +44,12 @@ class TestParser(TestCase):
 
             self._test_req_file(req_file=fn)
 
+    def test_skip_includes(self) -> None:
+        fp = join(TestParser._requirements_files_dir, 'recursive_1.txt')
+        with open(fp) as req_fh:
+            parsed = parse(req_fh, skip_includes=True)
+            self.assertEqual([p.line for p in parsed], ['Django==1.6'])
+
     def _test_req_file(self, req_file: str) -> None:
         fp = join(TestParser._requirements_files_dir, req_file)
         with open(fp) as req_fh:


### PR DESCRIPTION
Hi,

I'm building a tool to inspect requirement files of multiple Python projects (compare version numbers etc.). Your library works very nicely, and I'd like to propose this small update using which the requirements file "includes" ("-r" or "--requirement") can be ignored. Let me know if you're interested in applying this or if you'd like to have anything changed/improved in the PR.