### PR TITLE
Add setuptools as a runtime dep for pkg_resources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ keywords = [
 
 [tool.poetry.dependencies]
 python = "^3.6"
+setuptools = "*"
 # `types-setuptools` need to stay in sync with version of `setuptools` - but 47 was not typed...
 types-setuptools = ">= 57.0.0"
 


### PR DESCRIPTION
Add setuptools as a runtime dependency.

`pkg_resources` is being imported at runtime in `requirement.py` and this causes the library to fail to import in an environment without setuptools.

https://github.com/madpah/requirements-parser/issues/37 / https://github.com/madpah/requirements-parser/pull/38 seem related and seem to have had their fix lost to time