### PR TITLE
fix: only install files in package directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,9 @@ packages = [
     { include = "requirements" }
 ]
 include = [
-    "AUTHORS.rst",
-    "LICENSE",
-    "README.md"
+    { path = "AUTHORS.rst", format="sdist" },
+    { path = "LICENSE", format="sdist" },
+    { path = "README.md", format="sdist"},
 ]
 classifiers = [
     # Trove classifiers - https://packaging.python.org/specifications/core-metadata/#metadata-classifier


### PR DESCRIPTION
Fix https://github.com/madpah/requirements-parser/issues/66.
With this merge request, the package will not install files outside the package directory.

More, this merge request fixes the lintian error “ unknown-file-in-python-module-directory” in Debian. I want to help upload this fantastic package to the newest version (0.0.5) to Debian with this fix.