### PR TITLE
pyproject.toml: fix poetry sdist includes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ readme = "README.md"
 homepage = "https://github.com/madpah/requirements-parser"
 repository = "https://github.com/madpah/requirements-parser"
 packages = [
-    { include = "requirements" }
+    { include = "requirements" },
+    { include = "tests", format = "sdist" },
 ]
 include = [
     { path = "AUTHORS.rst", format = "sdist" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,9 @@ packages = [
     { include = "requirements" }
 ]
 include = [
-    "AUTHORS.rst",
-    "LICENSE",
-    "README.md"
+    { path = "AUTHORS.rst", format = "sdist" },
+    { path = "LICENSE", format = "sdist" },
+    { path = "README.md", format = "sdist" },
 ]
 classifiers = [
     # Trove classifiers - https://packaging.python.org/specifications/core-metadata/#metadata-classifier


### PR DESCRIPTION
Without specifying `format = "sdist"`, poetry installs these files
straight into the root site-packages directory.
