### PR TITLE
fix ValueError when parsing editable path without slashes

### DIFF
--- a/requirements/requirement.py
+++ b/requirements/requirement.py
@@ -165,7 +165,7 @@ class Requirement:
             req.path = cast(str, groups['path'])  # type: ignore
         else:
             req.local_file = True
-            req.path, req.name = line.rsplit('/', 1)  # type: ignore
+            req.path, _, req.name = line.rpartition('/')  # type: ignore
 
         return req
 


### PR DESCRIPTION
Related to #83? Seems like maybe a different error though.

This resolves an issue I'm getting when attempting to parse https://github.com/apache/superset/blob/89dbb9888cced762696347a610750755b539f2f0/requirements/base.txt. (Chokes on `-e file:.`.