### PR TITLE
Remove upper bound on Python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ keywords = [
 "Bug Tracker" = "https://github.com/madpah/requirements-parser/issues"
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = ">=3.8"
 packaging = ">=23.2"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
There is a bound on Python equivalent to <4.0. This causes problems solving environments and is unnecessary. See https://discuss.python.org/t/requires-python-upper-limits/12663 and https://iscinumpy.dev/post/bound-version-constraints/#pinning-the-python-version-is-special