### PR TITLE
Add Python 3.13 and 3.14 to the CI test matrix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ concurrency:
   cancel-in-progress: false  # prevent duplicates semantic-release
 
 env:
-  PYTHON_VERSION_DEFAULT: "3.12"
+  PYTHON_VERSION_DEFAULT: "3.13"
   POETRY_VERSION: "1.8.1"
 
 permissions:

--- a/.github/workflows/poetry.yml
+++ b/.github/workflows/poetry.yml
@@ -18,7 +18,7 @@ concurrency:
 
 env:
   REPORTS_DIR: CI_reports
-  PYTHON_VERSION_DEFAULT: "3.12"
+  PYTHON_VERSION_DEFAULT: "3.13"
   POETRY_VERSION: "1.8.1"
   TESTS_REPORTS_ARTIFACT: tests-reports
 
@@ -57,7 +57,7 @@ jobs:
         include:
           - # test with the locked dependencies
             os: ubuntu-latest
-            python-version: '3.12'
+            python-version: '3.13'
             toxenv-factors: '-current'
           - # test with the lowest dependencies
             os: ubuntu-latest
@@ -92,7 +92,9 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'windows-latest', 'macos-13']
         python-version:
-          - "3.12" # highest supported
+          - "3.14" # highest supported
+          - "3.13"
+          - "3.12"
           - "3.11"
           - "3.10"
           - "3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,12 +48,13 @@ classifiers = [
     'Topic :: Software Development :: Libraries :: Python Modules',
     'Topic :: System :: Software Distribution',
     'License :: OSI Approved :: Apache Software License',
-    'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: 3.14',
     'Typing :: Typed'
 ]
 keywords = [

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ minversion = 4.0
 envlist =
     flake8
     mypy-{current,lowest}
-    py{312,311,310,39,38}
+    py{314,313,312,311,310,39,38}
 skip_missing_interpreters = True
 usedevelop = False
 download = False


### PR DESCRIPTION
This pull request updates the Tox config and GitHub Actions workflows to test with Python 3.13 and 3.14.

Python 3.13 was released 2024-10-07[^1], and 3.14 will be released on 2025-10-07[^2].

[^1]: https://peps.python.org/pep-0719/
[^2]: https://peps.python.org/pep-0745/
